### PR TITLE
Fix.mocha.hang

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,19 +107,18 @@ module.exports = {
             },
 
             "done": function (filename, done, err) {
-                this.snap(filename).
-                    then(function (imageObject) {
-                        var output = (imageObject.imageUrl) ?
-                        "\nnemo-screenshot\n" + imageObject.imageUrl + "\n" :
-                        "\nnemo-screenshot::" + JSON.stringify(imageObject) + "::nemo-screenshot";
-                        if (err) {
-                            err.stack = err.stack + output;
-                        }
-                        done(err);
-                    }, function (scerror) {
-                        console.log("nemo-screenshot encountered some error.", scerror.toString());
-                        done(scerror);
-                    });
+                this.snap(filename).then(function (imageObject) {
+                    var output = (imageObject.imageUrl) ?
+                    "\nnemo-screenshot\n" + imageObject.imageUrl + "\n" :
+                    "\nnemo-screenshot::" + JSON.stringify(imageObject) + "::nemo-screenshot";
+                    if (err) {
+                        err.stack = err.stack + output;
+                    }
+                    done(err);
+                }, function (scerror) {
+                    console.log("nemo-screenshot encountered some error.", scerror.toString());
+                    done(scerror);
+                });
             }
         };
 
@@ -151,11 +150,11 @@ module.exports = {
                     if (session) {
                         var filename = 'ScreenShot_onException-' + process.pid + '-' + new Date().getTime();
                         var screenShotFileName = path.resolve(screenShotPath, filename);
-                        flow.wait(function () {
-                            return nemo.screenshot.snap(screenShotFileName).then(function () {
-                                exception._nemoScreenshotHandled = true;
-                                throw exception;
-                            }, 10000);
+                        nemo.screenshot.snap(screenShotFileName).then(function () {
+                            exception._nemoScreenshotHandled = true;
+                            throw exception;
+                        }, function (err) {
+                            throw err;
                         });
                     }
                 });

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
   },
   "devDependencies": {
     "chai": "~1.6.0",
+    "glob": "^7.0.3",
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-simple-mocha": "~0.4.0",
-    "mocha": "~1.10.0",
-    "nemo": "^2.0.0"
+    "mocha": "^2.4.5",
+    "nemo": "^2.0.0",
+    "rimraf": "^2.5.2"
   },
   "peerDependencies": {
     "nemo": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -32,12 +32,8 @@
     "selenium-webdriver"
   ],
   "author": "Matt Edelman",
-  "contributors": [
-    {
-      "name": "Pranav M. Pranav",
-      "email": "pmpranav@paypalcorp.com"
-    }
-  ],
+  "contributors": ["Pranav M. Pranav <pmpranav@paypalcorp.com>",
+    "Krzysztof Ostrowski <krzysztof.ostrowski@posteo.de>"],
   "dependencies": {
     "mkdirp": "~0.5.1"
   }

--- a/test/test.js
+++ b/test/test.js
@@ -4,77 +4,105 @@ var Nemo = require('nemo');
 var nemo;
 var assert = require('assert');
 var fs = require('fs');
+var glob = require('glob');
+var rm = require('rimraf');
 var path = require('path');
 var basedir = __dirname;
 var config = {
-  plugins: {
-    screenshot: {
-      module: 'path:../index',
-      arguments: ['path:report']
+    plugins: {
+        screenshot: {
+            module: 'path:../index',
+            arguments: ['path:report', ['exception']]
+        }
+    },
+    driver: {
+        browser: 'phantomjs'
     }
-  },
-  driver: {
-    browser: 'phantomjs'
-  }
 };
 var cleaner = function (cb) {
-  fs.unlink(path.resolve(__dirname, 'report/goog.png'), function (err) {
-    //ignore errors
-    fs.rmdir(path.resolve(__dirname, 'report'), function (err) {
-      //ignore errors
-      cb();
+    rm(path.resolve(__dirname, 'report'), {}, function (err) {
+        if (err) {
+            return cb(err);
+        }
+        cb();
     })
-  });
 };
 describe('nemo-screenshot', function () {
-  before(function (done) {
-    cleaner(function () {
-      nemo = Nemo(basedir, config, function (err) {
-        if (err) {
-          done(err);
-        }
+    before(function (done) {
+        cleaner(function (err) {
+            if (err) {
+                return done(err);
+            }
+            nemo = Nemo(basedir, config, function (err) {
+                if (err) {
+                    done(err);
+                }
+                done();
+            });
+        })
+
+
+    });
+    //afterEach(function (done) {
+    //    nemo.driver.getSession().then(function (session) {
+    //        if (!session) {
+    //            nemo.driver.quit().then(function () {
+    //                done();
+    //            }, function () {
+    //                done();
+    //            });
+    //        } else {
+    //            done();
+    //        }
+    //
+    //    })
+    //
+    //
+    //});
+    afterEach(function(done) {
+      //cleaner(function() {
         done();
-      });
-    })
+      //});
 
-
-  });
-  after(function (done) {
-      nemo.driver.quit().then(function () {
+    });
+    it('will get @setup@', function (done) {
+        assert(nemo.screenshot);
         done();
     });
+    it('will use @snap@ to take a screenshot', function (done) {
+        nemo.driver.get('http://www.google.com');
+        nemo.screenshot.snap('goog').then(function () {
+            //verify file exists
+            assert(fs.statSync(path.resolve(__dirname, 'report/goog.png')));
+            done();
+        });
 
-  });
-  afterEach(function (done) {
-    cleaner(function () {
-      done();
+    });
+    it('will use @done@ to take a screenshot', function (done) {
+        nemo.screenshot.done('goog', function fakeDone() {
+            assert(fs.statSync(path.resolve(__dirname, 'report/goog.png')));
+            done();
+        });
+    });
+    // not sure how to test this as an uncaughtException ALWAYS fails a mocha test
+    //it('will take a screenshot for an uncaughtException event', function (done) {
+    //        nemo.driver.get('http://www.google.com');
+    //        nemo.driver.findElement(nemo.wd.By.name('sfsfq')).sendKeys('foobar');
+    //        nemo.driver.sleep(1).then(function () {
+    //            console.log('foo')
+    //        }, function (err) {
+    //            done();
+    //        }).thenCatch(function (err) {
+    //            done();
+    //        });
+    //
+    //});
+    it('will use @done@error@ to take a screenshot in an error scenario', function (done) {
+        nemo.screenshot.done('goog', function fakeDone(err) {
+            assert(err.stack.indexOf('nemo-screenshot') !== -1);
+            assert(fs.statSync(path.resolve(__dirname, 'report/goog.png')));
+            done();
+        }, new Error('my error'));
     });
 
-  });
-  it('will get @setup@', function (done) {
-    assert(nemo.screenshot);
-    done();
-  });
-  it('will use @snap@ to take a screenshot', function (done) {
-    nemo.driver.get('http://www.google.com');
-    nemo.screenshot.snap('goog').then(function () {
-      //verify file exists
-      assert(fs.statSync(path.resolve(__dirname, 'report/goog.png')));
-      done();
-    });
-
-  });
-  it('will use @done@ to take a screenshot', function (done) {
-    nemo.screenshot.done('goog', function fakeDone() {
-      assert(fs.statSync(path.resolve(__dirname, 'report/goog.png')));
-      done();
-    });
-  });
-  it('will use @done@error@ to take a screenshot in an error scenario', function(done) {
-    nemo.screenshot.done('goog', function fakeDone(err) {
-      assert(err.stack.indexOf('nemo-screenshot') !== -1);
-      assert(fs.statSync(path.resolve(__dirname, 'report/goog.png')));
-      done();
-    }, new Error('my error'));
-  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -59,12 +59,7 @@ describe('nemo-screenshot', function () {
     //
     //
     //});
-    afterEach(function(done) {
-      //cleaner(function() {
-        done();
-      //});
 
-    });
     it('will get @setup@', function (done) {
         assert(nemo.screenshot);
         done();


### PR DESCRIPTION
using `flow.wait` was problematic because selenium empties its promise queue upon an uncaught exception. So, the "flow" would be dead when the screenshot promise was added.
## Testing
### Environment

Mac OS10.5.5, node@4.2.6, npm@3.7.3, nemo@2.0.0, nemo-screenshot@2.0.0, selenium-webdriver@2.48.2, mocha@2.4.5
### Mocha

--timeout of 20 seconds
### nemo-screenshot

enable exception screenshot capture
### Tests

Using this mocha test:

``` javascript
it('should automate the browser', function (done) {
    //login
    nemo.driver.get(nemo.data.baseUrl);
    nemo.view._waitVisible('id:signup-butston',10).click(); //click throws uncaughtException
    nemo.view._waitVisible('id:cta-btn').click();
    nemo.view._waitVisible('id:email').sendKeys('mynewpaypalaccount@geemail.paypal').then(done, done);
  });
```
#### single mocha suite

**nemo-screenshot 2.0.0** screenshot is taken, but suite hangs until mocha timeout of 20s
**nemo-screenshot with this fix** screenshot is taken, suite fails showing webdriver exception, expected behavior
#### multiple mocha suites (failing one somewhere in the middle)

Same results as above
