### PR TITLE
Adding a check for existence of driver session in Click event listener

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,14 +195,16 @@ module.exports = {
         // Adding event listeners to take automatic screenshot
         if (autoCaptureOptions.indexOf('click') !== -1) {
             flow.on(scheduleTask, function (task) {
-                driver.getSession().then(function (session) {
-                    if (session && task !== undefined && task.indexOf('WebElement.click') !== -1) {
-                        var filename = 'ScreenShot_onClick-' + process.pid + '-' + new Date().getTime();
-                        flow.wait(function () {
-                            return nemo.screenshot.snap(filename);
-                        }, 10000);
-                    }
-                });
+                if (driver.getSession()) {
+                    driver.getSession().then(function (session) {
+                        if (session && task !== undefined && task.indexOf('WebElement.click') !== -1) {
+                            var filename = 'ScreenShot_onClick-' + process.pid + '-' + new Date().getTime();
+                            flow.wait(function () {
+                                return nemo.screenshot.snap(filename);
+                            }, 10000);
+                        }
+                    });
+                }
             });
         }
 

--- a/index.js
+++ b/index.js
@@ -195,8 +195,7 @@ module.exports = {
         // Adding event listeners to take automatic screenshot
         if (autoCaptureOptions.indexOf('click') !== -1) {
             flow.on(scheduleTask, function (task) {
-                if (driver.getSession()) {
-                    driver.getSession().then(function (session) {
+                driver.getSession() && driver.getSession().then(function (session) {
                         if (session && task !== undefined && task.indexOf('WebElement.click') !== -1) {
                             var filename = 'ScreenShot_onClick-' + process.pid + '-' + new Date().getTime();
                             flow.wait(function () {
@@ -204,7 +203,6 @@ module.exports = {
                             }, 10000);
                         }
                     });
-                }
             });
         }
 

--- a/test/testQuitDriverAfterEachIteration.js
+++ b/test/testQuitDriverAfterEachIteration.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var Nemo = require('nemo');
+var nemo;
+var rm = require('rimraf');
+var path = require('path');
+var basedir = __dirname;
+var config = {
+    plugins: {
+        screenshot: {
+            module: 'path:../index',
+            arguments: ['path:report', ['exception', 'click']]
+        }
+    },
+    driver: {
+        browser: 'phantomjs'
+    }
+};
+var cleaner = function (cb) {
+    rm(path.resolve(__dirname, 'report'), {}, function (err) {
+        if (err) {
+            return cb(err);
+        }
+        cb();
+    });
+};
+describe('nemo-screenshot-quit-driver-for-each-iteration', function () {
+    beforeEach(function (done) {
+        cleaner(function (err) {
+            if (err) {
+                return done(err);
+            }
+            nemo = Nemo(basedir, config, function (err) {
+                if (err) {
+                    done(err);
+                } else {
+                    done();
+                }
+            });
+        });
+
+
+    });
+    afterEach(function (done) {
+        nemo.driver.quit().then(done);
+
+    });
+
+
+    for (var i=0; i<3; i++){
+        it('will test quit driver after each iteration for multiple iterations, iteration number:' + i, function (done) {
+            done();
+        });
+    }
+
+
+});


### PR DESCRIPTION
Adding a check for existence of driver session in Click event listener to fix a potential undefined error in certain cases. We were getting the following error without this check when Click capture is configured and test is configured to quit driver after each iteration when more than one test cases were present in the test suite.

TypeError: Cannot read property 'then' of undefined
    at index.js:198:36