### PR TITLE
Fix.click.impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # nemo-screenshot changelog
 
+## unreleased
+
+* simpler implementation of click screenshot that monkey patches WebElement.click
+
 ## v2.2.3
 
 * added a check in click event listener to prevent exception when driver.getSession() returns undefined value. See https://github.com/paypal/nemo-screenshot/pull/57

--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ module.exports = {
                 var filename = 'ScreenShot_onClick-' + process.pid + '-' + new Date().getTime();
                 return nemo.screenshot.snap(filename)
                     .then(oclick.bind(this));
-            }
+            };
         }
 
         if (autoCaptureOptions.indexOf('exception') !== -1) {

--- a/index.js
+++ b/index.js
@@ -196,7 +196,6 @@ module.exports = {
         if (autoCaptureOptions.indexOf('click') !== -1) {
             var oclick = nemo.wd.WebElement.prototype.click;
             nemo.wd.WebElement.prototype.click = function () {
-                var p = nemo.wd.promise.defer();
                 var filename = 'ScreenShot_onClick-' + process.pid + '-' + new Date().getTime();
                 return nemo.screenshot.snap(filename)
                     .then(oclick.bind(this));

--- a/index.js
+++ b/index.js
@@ -194,16 +194,13 @@ module.exports = {
 
         // Adding event listeners to take automatic screenshot
         if (autoCaptureOptions.indexOf('click') !== -1) {
-            flow.on(scheduleTask, function (task) {
-                driver.getSession() && driver.getSession().then(function (session) {
-                    if (session && task !== undefined && task.indexOf('WebElement.click') !== -1) {
-                        var filename = 'ScreenShot_onClick-' + process.pid + '-' + new Date().getTime();
-                        flow.wait(function () {
-                            return nemo.screenshot.snap(filename);
-                        }, 10000);
-                    }
-                });
-            });
+            var oclick = nemo.wd.WebElement.prototype.click;
+            nemo.wd.WebElement.prototype.click = function () {
+                var p = nemo.wd.promise.defer();
+                var filename = 'ScreenShot_onClick-' + process.pid + '-' + new Date().getTime();
+                return nemo.screenshot.snap(filename)
+                    .then(oclick.bind(this));
+            }
         }
 
         if (autoCaptureOptions.indexOf('exception') !== -1) {


### PR DESCRIPTION
Simpler/more reliable implementation of click capture, overrides WebElement.click.

Also doesn't rely on ControlFlow, which won't be valid for much longer:
https://github.com/SeleniumHQ/selenium/issues/2969