### PR TITLE
V2.fix.exception.handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # nemo-screenshot changelog
 
+## UNRELEASED
+
+* modify exception handler pattern to use the ControlFlow `emit` method. fix unit test for the same
+
 ## v2.2.5
 
 * resolve newer webdriver promise syntax and conditionally use native promises if available. fixes #61 

--- a/index.js
+++ b/index.js
@@ -98,16 +98,6 @@ function formatJenkinsImageUrls(screenShotPath, imageName) {
     }
 }
 
-/**
- * Error thrown in uncaught exception handler is silenced for selenium-webdirver-2.52 onwards.
- * The workaround is to throw error asynchronously.
- * Ref: https://github.com/SeleniumHQ/selenium/issues/2770
- */
-function asyncThrow(err) {
-    setTimeout(function () {
-        throw err;
-    }, 0);
-}
 
 module.exports = {
     /**

--- a/index.js
+++ b/index.js
@@ -227,7 +227,7 @@ module.exports = {
         if (autoCaptureOptions.indexOf('exception') !== -1) {
             flow.on(uncaughtException, function (exception) {
                 if (exception._nemoScreenshotHandled) {
-                    asyncThrow(exception);
+                    flow.emit(uncaughtException, exception);
                 }
 
                 exception._nemoScreenshotHandled = true;
@@ -242,14 +242,14 @@ module.exports = {
 
                         nemo.screenshot.snap(filename).then(function (imageObject) {
                             appendImageUrlToStackTrace(imageObject, exception);
-                            throw exception;
+                            flow.emit(uncaughtException, exception);
                         });
                     } else {
                         throw exception;
                     }
-                }).thenCatch(function (e) {
+                }).catch(function (e) {
                     e._nemoScreenshotHandled = true;
-                    asyncThrow(e);
+                    flow.emit(uncaughtException, exception);
                 });
             });
         }

--- a/test/test.js
+++ b/test/test.js
@@ -44,22 +44,7 @@ describe('nemo-screenshot', function () {
 
 
     });
-    //afterEach(function (done) {
-    //    nemo.driver.getSession().then(function (session) {
-    //        if (!session) {
-    //            nemo.driver.quit().then(function () {
-    //                done();
-    //            }, function () {
-    //                done();
-    //            });
-    //        } else {
-    //            done();
-    //        }
-    //
-    //    })
-    //
-    //
-    //});
+
 
     it('will get @setup@', function (done) {
         assert(nemo.screenshot);
@@ -80,19 +65,17 @@ describe('nemo-screenshot', function () {
             done();
         });
     });
-    // not sure how to test this as an uncaughtException ALWAYS fails a mocha test
-    // it('will take a screenshot for an uncaughtException event', function (done) {
-    //     nemo.driver.get('http://www.google.com');
-    //     nemo.driver.findElement(nemo.wd.By.name('sfsfq')).sendKeys('foobar');
-    //     nemo.driver.sleep(1).then(function () {
-    //         console.log('foo')
-    //     }, function (err) {
-    //         done();
-    //     }).thenCatch(function (err) {
-    //         done();
-    //     });
-    // });
 
+    it('will take a screenshot for an uncaughtException event', function (done) {
+        function unExList(ex) {
+            console.log(ex);
+            nemo.driver.controlFlow().removeListener('uncaughtException', unExList);
+            done();
+        }
+        nemo.driver.get('http://www.google.com');
+        nemo.driver.findElement(nemo.wd.By.name('sfsfq')).sendKeys('foobar');
+        nemo.driver.controlFlow().on('uncaughtException', unExList);
+    });
     it('will use @done@error@ to take a screenshot in an error scenario', function (done) {
         nemo.screenshot.done('goog', function fakeDone(err) {
             assert(err.stack.indexOf('nemo-screenshot') !== -1);
@@ -100,5 +83,6 @@ describe('nemo-screenshot', function () {
             done();
         }, new Error('my error'));
     });
+
 
 });


### PR DESCRIPTION
using the ControlFlow.emit method is a cleaner way to pass along the exception after taking a screenshot. also fixed the associated unit test.